### PR TITLE
Fix typo in `Mailservers` spec

### DIFF
--- a/spec/builtin/dns/mailservers_spec.rb
+++ b/spec/builtin/dns/mailservers_spec.rb
@@ -15,7 +15,7 @@ describe Ronin::Recon::DNS::Mailservers do
         ]
       end
 
-      it "must yield Mailsever values" do
+      it "must yield Mailserver values" do
         yielded_values = []
 
         Async do


### PR DESCRIPTION
Mailse[r]ver