### PR TITLE
Change `Cert#cert` return value description

### DIFF
--- a/lib/ronin/recon/values/cert.rb
+++ b/lib/ronin/recon/values/cert.rb
@@ -31,7 +31,7 @@ module Ronin
 
         # The certificate object.
         #
-        # @return [OpenSSL::X509::Certificate]
+        # @return [Ronin::Support::Crypto::Cert]
         #
         # @api private
         attr_reader :cert


### PR DESCRIPTION
Few months ago I've changed `@cert` initialization to `Support::Crypto::Cert(cert)`, but I didnt change the description